### PR TITLE
Add code of conduct file - closes #44

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,80 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders of this project pledge to make participation in our community a respectful, inclusive, and harassment-free experience for everyone. We commit to ensuring that everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, education level, socio-economic status, nationality, personal appearance, race, caste, religion, or sexual identity and orientation, feels welcome and safe.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Values 
+
+We value creativity, curiosity, and kindness.  
+We believe in mentoring newcomers and lifting each other up as we grow together.  
+All contributors, whether beginners or experts, are welcome here.  
+We encourage respectful dialogue and constructive feedback that helps us build a better open-source world.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes
+- Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Project maintainers are responsible for clarifying and enforcing our standards of acceptable behavior. They will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned with this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all project spaces, including GitHub repositories, issue trackers, pull requests, discussions, and all communication mediums, as well as in public spaces when an individual is representing the project or its community.
+
+Examples of representing a project include using an official project email address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the project team at [fewinfos@gmail.com]. All complaints will be reviewed and investigated promptly and fairly.
+
+All project team members are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Project maintainers will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+**Impact:** Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.  
+**Consequence:** A private, written warning from project maintainers, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+**Impact:** A violation through a single incident or series of actions.  
+**Consequence:** A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+**Impact:** A serious violation of community standards, including sustained inappropriate behavior.  
+**Consequence:** A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including maintainers. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+**Impact:** Demonstrating a pattern of violation or serious breach of trust.  
+**Consequence:** A permanent ban from any sort of public interaction within the project’s community spaces.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at:  
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+
+Community Impact Guidelines were inspired by [Mozilla’s code of conduct enforcement ladder](https://github.com/mozilla/diversity).
+
+---
+

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -45,7 +45,7 @@ Examples of representing a project include using an official project email addre
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the project team at [fewinfos@gmail.com]. All complaints will be reviewed and investigated promptly and fairly.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the project team at [fewinfos [at] gmail [dot] com]. All complaints will be reviewed and investigated promptly and fairly.
 
 All project team members are obligated to respect the privacy and security of the reporter of any incident.
 


### PR DESCRIPTION
✅ Added Code of Conduct

Introduced a CODE_OF_CONDUCT.md file based on Contributor Covenant.

Outlined the values and behavior expected from all contributors.

Included reporting instructions for concerns or violations.